### PR TITLE
popoverAPI enabled by default, any anchor element

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import { flip } from "@floating-ui/dom";
 
 function App() {
   return (
-    <div style="display: flex; align-items: center; justify-content: center; height: 100dvh;">
+    <div style="display: flex; flex-direction: column; gap: 4rem; align-items: center; justify-content: center; height: 100dvh;">
+      <div id="anchor-element">anchor</div>
       <Popover
         defaultOpen
         // Minimalistic
@@ -21,7 +22,7 @@ function App() {
         // ------------------------------- The following props are optional
         // Full control over position
         autoUpdate
-        computePositionOptions={{ placement: "bottom", middleware: [flip()] }}
+        computePositionOptions={{ placement: "bottom-start", middleware: [flip()] }}
         // Popover API support (where possible)
         usePopoverAPI
         // When popover API is not supported, fallback to mounting content to body
@@ -29,8 +30,7 @@ function App() {
         dataAttributeName="data-open"
         // SSR support
         //mount="body"
-        // Astro support
-        anchorElementSelector="#trigger-button"
+        anchorElementSelector="#anchor-element"
         contentElementSelector="div"
       />
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -22,10 +22,6 @@ a:hover {
   color: #535bf2;
 }
 
-body {
-
-}
-
 button {
   display: block;
 }
@@ -52,4 +48,8 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+#anchor-element {
+  border: 1px solid red;
 }

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -34,8 +34,8 @@ export type PopoverProps = {
    * If set to null no event would trigger popover,
    * so you need to trigger it mannually.
    * Event name or list of event names separated by "|" which triggers popover.
-   * You may also add modifiers like "capture", "passive", "once" to the event separated by ".":
-   * @example "pointerdown.capture.once"
+   * You may also add modifiers like "capture", "passive", "once", "prevent", "stop" to the event separated by ".":
+   * @example "pointerdown.capture.once.prevent|click"
    */
   triggerEvents?: string | null;
   /**
@@ -169,6 +169,9 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
       trigger.addEventListener(
         eventName,
         (e: Event) => {
+          if (modifiers.includes("prevent")) e.preventDefault();
+          if (modifiers.includes("stop")) e.stopPropagation();
+
           // don't trigger if trigger is disabled
           if (e.target && "disabled" in e.target && e.target.disabled) return;
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -165,12 +165,13 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
 
     events.forEach((event) => {
       const [eventName, ...modifiers] = event.split(".");
+      const modifiersSet = new Set(modifiers);
 
       trigger.addEventListener(
         eventName,
         (e: Event) => {
-          if (modifiers.includes("prevent")) e.preventDefault();
-          if (modifiers.includes("stop")) e.stopPropagation();
+          if (modifiersSet.has("prevent")) e.preventDefault();
+          if (modifiersSet.has("stop")) e.stopPropagation();
 
           // don't trigger if trigger is disabled
           if (e.target && "disabled" in e.target && e.target.disabled) return;
@@ -182,9 +183,9 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
         },
         {
           signal: abortController.signal,
-          capture: modifiers.includes("capture"),
-          passive: modifiers.includes("passive"),
-          once: modifiers.includes("once"),
+          capture: modifiersSet.has("capture"),
+          passive: modifiersSet.has("passive"),
+          once: modifiersSet.has("once"),
         }
       );
     });

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -31,10 +31,11 @@ export type PopoverProps = {
   computePositionOptions?: ComputePositionConfig;
   /**
    * @default "pointerdown"
-   * if set to null no event would trigger popover,
+   * Event name or list of event names separated by "|" which triggers popover.
+   * If set to null no event would trigger popover,
    * so you need to trigger it mannually
    */
-  triggerEvent?: string | null;
+  triggerEvents?: string | null;
   /**
    * HTMLElement or CSS selector (can be used in SSR) to mount popover content into
    */
@@ -51,7 +52,7 @@ export type PopoverProps = {
    */
   dataAttributeName?: string;
   /**
-   * CSS selector to find anchor html element inside trigger
+   * CSS selector to find anchor html element
    * Can be used with Astro, because astro wraps trigger element into astro-slot
    * and position breaks
    */
@@ -72,7 +73,10 @@ export type PopoverProps = {
    * @see https://floating-ui.com/docs/autoupdate#options
    */
   autoUpdateOptions?: AutoUpdateOptions;
-  /** Use popover API where possible */
+  /**
+   * Use popover API where possible
+   * @default true
+   */
   usePopoverAPI?: boolean;
   /**
    * Close popover on escape key press.
@@ -83,6 +87,7 @@ export type PopoverProps = {
   /**
    * HTMLElement or CSS selector (can be used in SSR) to mount popover content into
    * Fallback for browsers that don't support Popover API
+   * @default body
    */
   popoverAPIMountFallback?: HTMLElement | string;
   onOpenChange?: (open: boolean) => void;
@@ -115,10 +120,12 @@ const getMountElement = (mountTarget: HTMLElement | string): HTMLElement => {
 };
 
 const DEFAULT_PROPS = Object.freeze({
-  triggerEvent: "pointerdown",
+  triggerEvents: "pointerdown",
   dataAttributeName: "data-popover-open",
   closeOnEscape: true,
   closeOnOutsideInteraction: true,
+  usePopoverAPI: true,
+  popoverAPIMountFallback: "body",
   computePositionOptions: {
     /**
      * Default position here is absolute, because there might be some bugs in safari with "fixed" position
@@ -133,16 +140,6 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
 
   const resolvedTrigger = children(() => props.trigger);
 
-  const handleTrigger = (e: Event) => {
-    // don't trigger if trigger is disabled
-    if (e.target && "disabled" in e.target && e.target.disabled) return;
-
-    const newOpenValue = !open();
-    // if uncontrolled, set open state
-    if (props.open === undefined) setOpen(newOpenValue);
-    props.onOpenChange?.(newOpenValue);
-  };
-
   // sync state with props
   createComputed(
     on(
@@ -156,19 +153,36 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
   );
 
   createEffect(() => {
-    const event = props.triggerEvent === undefined ? DEFAULT_PROPS.triggerEvent : props.triggerEvent;
-    if (!event) return;
+    const events = (props.triggerEvents === undefined ? DEFAULT_PROPS.triggerEvents : props.triggerEvents)?.split("|");
+
+    if (events === undefined || events.length === 0) return;
     if (props.disabled) return;
 
-    const trigger = getElement(resolvedTrigger, props.anchorElementSelector);
-    trigger.addEventListener(event, handleTrigger);
+    const abortController = new AbortController();
+    const trigger = getElement(resolvedTrigger);
 
-    onCleanup(() => trigger.removeEventListener(event, handleTrigger));
+    events.forEach((event) =>
+      trigger.addEventListener(
+        event,
+        (e: Event) => {
+          // don't trigger if trigger is disabled
+          if (e.target && "disabled" in e.target && e.target.disabled) return;
+
+          const newOpenValue = !open();
+          // if uncontrolled, set open state
+          if (props.open === undefined) setOpen(newOpenValue);
+          props.onOpenChange?.(newOpenValue);
+        },
+        { signal: abortController.signal }
+      )
+    );
+
+    onCleanup(() => abortController.abort());
   });
 
   createEffect(() => {
     const dataAttributeName = props.dataAttributeName ?? DEFAULT_PROPS.dataAttributeName;
-    const trigger = getElement(resolvedTrigger, props.anchorElementSelector);
+    const trigger = getElement(resolvedTrigger);
 
     createEffect(() => trigger.setAttribute(dataAttributeName, String(open())));
 
@@ -183,8 +197,14 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
           const resolvedContent = children(() => props.content);
 
           createEffect(() => {
-            const trigger = getElement(resolvedTrigger, props.anchorElementSelector);
+            const trigger = getElement(resolvedTrigger);
             const content = getElement(resolvedContent, props.contentElementSelector);
+            const anchorElement = props.anchorElementSelector
+              ? document.querySelector(props.anchorElementSelector)
+              : trigger;
+
+            if (!(anchorElement instanceof HTMLElement)) throw new Error("Unable to find anchor element");
+
             // Hack for astro
             const contentToMount = getElement(resolvedContent);
 
@@ -274,9 +294,9 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
                 // for correct placement we need to set width of content before computing position
                 // You may consider adding 'width: max-content' by yourself
                 // @see https://floating-ui.com/docs/computePosition
-                if (props.sameWidth) content.style.width = `${trigger.clientWidth}px`;
+                if (props.sameWidth) content.style.width = `${anchorElement.clientWidth}px`;
 
-                computePosition(trigger, content, options).then(({ x, y }) => {
+                computePosition(anchorElement, content, options).then(({ x, y }) => {
                   content.style.top = `${y}px`;
                   content.style.left = `${x}px`;
                   content.style.position = options?.strategy ?? DEFAULT_PROPS.computePositionOptions.strategy;
@@ -288,7 +308,7 @@ export const Popover: VoidComponent<PopoverProps> = (props) => {
               createEffect(() => {
                 if (!props.autoUpdate) return;
 
-                const cleanupAutoupdate = autoUpdate(trigger, content, updatePosition, props.autoUpdateOptions);
+                const cleanupAutoupdate = autoUpdate(anchorElement, content, updatePosition, props.autoUpdateOptions);
 
                 onCleanup(() => cleanupAutoupdate());
               });


### PR DESCRIPTION
Added support for arbitrary anchor element. By default it's trigger, but it's possible to customize it via `anchorElementSelector`.

Now popover API enabled by default with `popoverAPIMountFallback="body"`.

Also added support for multiple trigger events. You may pass them via "|". It's possible to pass modifiers for the event like "capture", "passive", "once", "prevent", "stop": `triggerEvents="pointerdown.capture.once.prevent|click"`